### PR TITLE
Fix mode-line truncation in narrow window and internal cleanup

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,8 +2,14 @@
 
 * Changelog
 
-** Unreleased
+** 0.2.0
 
+- ~Fixed~ Fixed tests and fixed linting errors.
+- ~Changed~ Simplified ~...--get-symbol~, gets called with variable name directly now, now need for ~intern-soft~.
+- ~Changed~ ~...--vc-branch-get~ was brittle if for some reason the ~vc-mode~ would not be of the right length.
+- ~Changed~ Some little optimizations and fixes.
+- ~Changed~ ~winum-auto-setup-modeline~ is disabled when activating the modeline instead of each time the segment ist recalculated (inefficient).
+- ~Fixed~ If the text in the modeline is too long, it gets truncated and tries to be sort of intelligent. For this I added a new segment ~:left-important~. This segment has the highest priority and is truncated in the very end if needed. ~:left~ ist the first segment to be truncated if needed followed by ~:right~.
 - ~Added~ If the scroll bar is enabled it is also taken into account when calculating the alignment of the right segment.
 - =Fixed= Aligning with ~fringes-outside-margins~ set to ~nil~ was not working correctly.
 - =Changed= Snapshot Emacs version using continue-on-error: true now.

--- a/Eask
+++ b/Eask
@@ -7,7 +7,7 @@
 ;; Domain Specific Language
 ;; https://emacs-eask.github.io/DSL/
 (package "lordar-mode-line"
-         "0.1.0"
+         "0.2.0"
          "Minimal mode-line")
 
 (website-url "https://github.com/hubisan/lordar-mode-line")
@@ -38,3 +38,6 @@
 
 ;; Dont' check docstring for correct verb use.
 (setq checkdoc-verb-check-experimental-flag nil)
+
+;; Ingnore unsafe variables to not get prompted while testing.
+(setq enable-local-variables :safe)

--- a/README.org
+++ b/README.org
@@ -58,6 +58,8 @@ To activate the mode line use ~lordar-mode-line-mode~. This will setup up the de
 
 To modify the definitions change the variables ~lordar-mode-line-default-segments~, ~lordar-mode-line-prog-mode-segments~ or ~lordar-mode-line-minimal-segments~.
 
+Each segments variable is a plist with the keys ~:left-important~, ~:left~, and ~:right~. Segments under ~:left-important~ are kept visible as long as possible when space is tight; ~:left~ is truncated first. ~:right~ is aligned to the right.
+
 To define a custom mode-line for a major mode with the segments provided
 - create a new variable holding the segments for the left and right side and
 - modify ~lordar-mode-line-major-mode-definitions~ to include your new mode-line definition. 
@@ -109,17 +111,18 @@ The following segments are available:
 
 Set the following variables to change the behaviour of the package:
 
-- lordar-mode-line-default-segments :: Default segments used for the mode line. The default is:
+- lordar-mode-line-default-segments :: Default segments used for the mode line. The plist keys are ~:left-important~, ~:left~, and ~:right~. ~:left-important~ is prioritized when the available width is too small. The default is:
   #+BEGIN_SRC emacs-lisp
     (setq lordar-mode-line-default-segments
-          '(:left
+          '(:left-important
             ((lordar-mode-line-segments-adjust-height)
              (lordar-mode-line-segments-winum " %s ")
              (lordar-mode-line-segments-evil-state " %s ")
              (lordar-mode-line-segments-buffer-status
               (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
-             (lordar-mode-line-segments-buffer-name "%s")
-             (lordar-mode-line-segments-project-root-relative-directory " %s"))
+             (lordar-mode-line-segments-buffer-name "%s"))
+            :left
+            ((lordar-mode-line-segments-project-root-relative-directory " %s"))
             :right
             ((lordar-mode-line-segments-vc-state
               (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
@@ -131,14 +134,15 @@ Set the following variables to change the behaviour of the package:
 - lordar-mode-line-prog-mode-segments :: Segments used for the mode line in `prog-mode'. The default is:
   #+BEGIN_SRC emacs-lisp
     (setq lordar-mode-line-prog-mode-segments
-          '(:left
+          '(:left-important
             ((lordar-mode-line-segments-adjust-height)
              (lordar-mode-line-segments-winum " %s ")
              (lordar-mode-line-segments-evil-state " %s ")
              (lordar-mode-line-segments-buffer-status
               (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
-             (lordar-mode-line-segments-buffer-name "%s")
-             (lordar-mode-line-segments-project-root-relative-directory " %s"))
+             (lordar-mode-line-segments-buffer-name "%s"))
+            :left
+            ((lordar-mode-line-segments-project-root-relative-directory " %s"))
             :right
             ((lordar-mode-line-segments-syntax-checking-error-counter "%s ")
              (lordar-mode-line-segments-syntax-checking-warning-counter "%s ")
@@ -152,13 +156,14 @@ Set the following variables to change the behaviour of the package:
 - lordar-mode-line-minimal-segments :: Minimal segments for mode like `special-mode'. The default is:
   #+BEGIN_SRC emacs-lisp
     (setq lordar-mode-line-minimal-segments
-          '(:left
+          '(:left-important
             ((lordar-mode-line-segments-adjust-height)
              (lordar-mode-line-segments-winum " %s ")
              (lordar-mode-line-segments-evil-state " %s ")
              (lordar-mode-line-segments-buffer-status
               (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
              (lordar-mode-line-segments-buffer-name "%s"))
+            :left nil
             :right
             ((lordar-mode-line-segments-major-mode "%s "))))
   #+END_SRC
@@ -176,7 +181,7 @@ Set the following variables to change the behaviour of the package:
 - lordar-mode-line-buffer-status-symbols :: Symbols for buffer status (segment: lordar-mode-line-segments-buffer-status) in the mode line. Each entry is a cons cell with a keyword and a corresponding string. Default:
   #+BEGIN_SRC emacs-lisp
     (setq lordar-mode-line-buffer-status-symbols
-          ((buffer-not-modified)
+          ((buffer-not-modified . nil)
            (buffer-modified . "*")
            (buffer-read-only . "%")))
   #+END_SRC
@@ -188,7 +193,7 @@ Set the following variables to change the behaviour of the package:
            (needs-update . "!u") (needs-merge . "!m")
            (added . "*") (removed . "x")
            (conflict . "!c") (ignored . "x")
-           (default)))
+           (default . nil)))
   #+END_SRC
 
 *** Faces

--- a/lisp/lordar-mode-line-core.el
+++ b/lisp/lordar-mode-line-core.el
@@ -36,14 +36,15 @@
   :group 'lordar-mode-line)
 
 (defcustom lordar-mode-line-default-segments
-  '(:left
+  '(:left-important
     ((lordar-mode-line-segments-adjust-height)
      (lordar-mode-line-segments-winum " %s ")
      (lordar-mode-line-segments-evil-state " %s ")
      (lordar-mode-line-segments-buffer-status
       (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
-     (lordar-mode-line-segments-buffer-name "%s")
-     (lordar-mode-line-segments-project-root-relative-directory " %s"))
+     (lordar-mode-line-segments-buffer-name "%s"))
+    :left
+    ((lordar-mode-line-segments-project-root-relative-directory " %s"))
     :right
     ((lordar-mode-line-segments-vc-state
       (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
@@ -51,24 +52,26 @@
      (lordar-mode-line-segments-major-mode "%s ")
      (lordar-mode-line-segments-input-method " %s ")))
   "Default segments used for the mode line.
-The :left key defines segment functions or strings to be displayed on the left
-side of the mode line, while the :right key defines those for the right side.
-Some segment functions support additional arguments."
+The :left-important key defines segments that should remain visible even
+if space is tight. The :left key defines standard left segments, and
+:right defines those for the right side."
   :group 'lordar-mode-line
   :type '(plist :tag "Mode Line Segments"
-                :key-type (choice (const :tag "Left Segments" :left)
+                :key-type (choice (const :tag "Left Important Segments" :left-important)
+                                  (const :tag "Left Segments" :left)
                                   (const :tag "Right Segments" :right))
                 :value-type (repeat :tag "Segment Function or String" sexp)))
 
 (defcustom lordar-mode-line-prog-mode-segments
-  '(:left
+  '(:left-important
     ((lordar-mode-line-segments-adjust-height)
      (lordar-mode-line-segments-winum " %s ")
      (lordar-mode-line-segments-evil-state " %s ")
      (lordar-mode-line-segments-buffer-status
       (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
-     (lordar-mode-line-segments-buffer-name "%s")
-     (lordar-mode-line-segments-project-root-relative-directory " %s"))
+     (lordar-mode-line-segments-buffer-name "%s"))
+    :left
+    ((lordar-mode-line-segments-project-root-relative-directory " %s"))
     :right
     ((lordar-mode-line-segments-syntax-checking-error-counter "%s ")
      (lordar-mode-line-segments-syntax-checking-warning-counter "%s ")
@@ -78,32 +81,36 @@ Some segment functions support additional arguments."
      (lordar-mode-line-segments-vc-branch "%s ")
      (lordar-mode-line-segments-major-mode "%s ")))
   "Segments used for the mode line in `prog-mode'.
-The :left key defines segment functions or strings to be displayed on the left
-side of the mode line, while the :right key defines those for the right side.
-Some segment functions support additional arguments."
+The :left-important key defines segments that should remain visible even
+if space is tight. The :left key defines standard left segments, and
+:right defines those for the right side."
   :group 'lordar-mode-line
   :type '(plist :tag "Mode Line Segments"
-                :key-type (choice (const :tag "Left Segments" :left)
+                :key-type (choice (const :tag "Left Important Segments"
+                                         :left-important)
+                                  (const :tag "Left Segments" :left)
                                   (const :tag "Right Segments" :right))
                 :value-type (repeat :tag "Segment Function or String" sexp)))
 
 (defcustom lordar-mode-line-minimal-segments
-  '(:left
+  '(:left-important
     ((lordar-mode-line-segments-adjust-height)
      (lordar-mode-line-segments-winum " %s ")
      (lordar-mode-line-segments-evil-state " %s ")
      (lordar-mode-line-segments-buffer-status
       (concat "%s" (lordar-mode-line-segments-vertical-space 0.4)))
      (lordar-mode-line-segments-buffer-name "%s"))
+    :left nil
     :right
     ((lordar-mode-line-segments-major-mode "%s ")))
   "Minimal segments used for the mode line.
-The :left key defines segment functions or strings to be displayed on the left
-side of the mode line, while the :right key defines those for the right side.
-Some segment functions support additional arguments."
+The :left-important key defines segments that should remain visible even
+if space is tight. The :left key defines standard left segments, and
+:right defines those for the right side."
   :group 'lordar-mode-line
   :type '(plist :tag "Mode Line Segments"
-                :key-type (choice (const :tag "Left Segments" :left)
+                :key-type (choice (const :tag "Left Important Segments" :left-important)
+                                  (const :tag "Left Segments" :left)
                                   (const :tag "Right Segments" :right))
                 :value-type (repeat :tag "Segment Function or String" sexp)))
 
@@ -220,21 +227,22 @@ If it is a string propertize it with the default face."
 
 (defun lordar-mode-line--construct-string (segments)
   "Construct a mode line string from SEGMENTS with left and right alignment.
-SEGMENTS is a plist with keys :left and :right. Each side contains a list of
-evaluated mode line segments.
+SEGMENTS is a plist with keys :left-important, :left and :right. Each side
+contains a list of evaluated mode line segments. Left-important is priorised if
+the lenght of the desired mode-line text exceeds the available width.
 
 Pixel alignment for the right side is done by calculating the necessary padding
 using the following steps:
 
-   Start at the right margin:
-                         |
-   Add the right margin width, the right fringe width (only if it lies outside
-   the margins), and the scroll bar width (if enabled), to reach the visible
-   window edge:
-                         |--margin-->|--fringe-->|--scroll bar-->|
-   Subtract the pixel width of the right segment (in chars, as a float) to get
-   the position where the right segment should start:
-             |<---------------------- right segment text --------|
+Start at the right margin:
+                      |
+Add the right margin width, the right fringe width (only if it lies outside
+the margins), and the scroll bar width (if enabled), to reach the visible
+window edge:
+                      |--margin-->|--fringe-->|--scroll bar-->|
+Subtract the pixel width of the right segment (in chars, as a float) to get
+the position where the right segment should start:
+          |<---------------------- right segment text --------|
 
 See Info node `(elisp)Pixel Specification' for more information about the
 `:align-to' display specification.
@@ -242,25 +250,62 @@ See Info node `(elisp)Pixel Specification' for more information about the
 Whether fringes are outside the margins is determined using `window-fringes',
 not the variable `fringes-outside-margins', because the window layout can also
 be set directly via `set-window-fringes', bypassing that variable."
-  (let* ((left-segments (plist-get segments :left))
-         (right-segments (plist-get segments :right))
-         (left-text (when left-segments
-                      (mapconcat #'lordar-mode-line--eval-segment left-segments)))
-         (right-text (when right-segments
-                       (mapconcat #'lordar-mode-line--eval-segment right-segments)))
-         (right-width (/ (string-pixel-width right-text) (float (frame-char-width))))
+  (let* ((left-important-segs (plist-get segments :left-important))
+         (left-segs (plist-get segments :left))
+         (right-segs (plist-get segments :right))
+         (face (lordar-mode-line--segments-get-face))
+         ;; eval segments (once)
+         (left-important-text
+          (if left-important-segs
+              (mapconcat #'lordar-mode-line--eval-segment left-important-segs)
+            ""))
+         (left-text
+          (if left-segs
+              (mapconcat #'lordar-mode-line--eval-segment left-segs)
+            ""))
+         (right-text
+          (if right-segs
+              (mapconcat #'lordar-mode-line--eval-segment right-segs)
+            ""))
+         ;; Not sure if ths is the correct width, but in testing it works.
+         (win-width (window-total-width))
+         (left-important-width (string-width left-important-text))
+         ;; available for: left-text + right-text
+         (avail (max 0 (- win-width left-important-width)))
+         ;; allocate space: keep right as much as possible
+         (right-desired-width (string-width right-text))
+         (right-space (min right-desired-width avail))
+         (left-space (max 0 (- avail right-space)))
+         ;; truncate left (cut on the right)
+         (left-text
+          (if (> left-space 0)
+              (truncate-string-to-width left-text left-space)
+            ""))
+         ;; Truncate right (cut on the left -> keep the end)
+         (right-text
+          (if (> left-space 0)
+              right-text
+            (if (> right-space 0)
+                (substring right-text
+                           (min (1- right-desired-width)
+                                (max 0 (- right-desired-width right-space))))
+              "")))
+         ;; Pixel-based align-to padding, computed with FINAL right-text
          (fringes-outside-p (nth 2 (window-fringes)))
          (fringe-adjust (if fringes-outside-p -1.0 0.0))
-         (padding (propertize
-                   " " 'display
-                   `(space :align-to
-                           (- right-margin
-                              (,fringe-adjust . right-fringe)
-                              (-1.0 . right-margin)
-                              (-1.0 . scroll-bar)
-                              ,right-width))
-                   'face (lordar-mode-line--segments-get-face))))
-    (concat left-text padding right-text)))
+         (right-width-float (/ (string-pixel-width right-text)
+                               (float (frame-char-width))))
+         (padding
+          (propertize
+           " " 'display
+           `(space :align-to
+                   (- right-margin
+                      (,fringe-adjust . right-fringe)
+                      (-1.0 . right-margin)
+                      (-1.0 . scroll-bar)
+                      ,right-width-float))
+           'face face)))
+    (concat left-important-text left-text padding right-text)))
 
 ;;;; Setup
 
@@ -318,6 +363,10 @@ When REMOVE is non-nil remove the advices else add the advices."
 
 (defun lordar-mode-line--setup-activate ()
   "Activate the lordar-mode-line."
+  ;; Need to disable this to not make it try to add itself to the mode-line.
+  (with-eval-after-load 'winum
+    (when (boundp 'winum-auto-setup-mode-line)
+      (setq winum-auto-setup-mode-line nil)))
   (lordar-mode-line-set-mode-line nil t)
   ;; Change mode line in active buffers.
   (dolist (buffer (buffer-list))

--- a/lisp/lordar-mode-line-segments.el
+++ b/lisp/lordar-mode-line-segments.el
@@ -51,19 +51,19 @@
 
 ;;;; Segments Auxiliary Functions & Variables
 
-(defun lordar-mode-line-segments--get-symbol (key symbols)
-  "Return the symbol associated with KEY from SYMBOLS alist.
-SYMBOLS is the symbol without the prefix lordar-mode-line and without
-the symbols suffix. For instance, buffer-status gets turned into
-`lordar-mode-line-buffer-status-symbols'."
-  (let* ((symbols-string (concat "lordar-mode-line-" (symbol-name symbols)
-                                 "-symbols"))
-         (symbols-alist (symbol-value (intern-soft symbols-string))))
-    (unless symbols-alist
-      (user-error "Symbols alist %s doesn't exist" symbols-string))
-    (if (assoc key symbols-alist)
-        (alist-get key symbols-alist)
-      (user-error "Symbol %s doesn't exist in %s" key symbols-string))))
+(defun lordar-mode-line-segments--get-symbol (key symbols-var)
+  "Return the value associated with KEY from SYMBOLS-VAR.
+SYMBOLS-VAR must be a symbol naming a variable whose value is an alist.
+The alist value may contain nil values intentionally."
+  (unless (symbolp symbols-var)
+    (user-error "SYMBOLS-VAR must be a symbol, got: %S" symbols-var))
+  (unless (boundp symbols-var)
+    (user-error "Symbols variable %S is not bound" symbols-var))
+  (let* ((symbols-alist (symbol-value symbols-var))
+         (cell (assq key symbols-alist)))
+    (if cell
+        (cdr cell)  ;; may be nil intentionally
+      (user-error "Symbol %s doesn't exist in %S" key symbols-var))))
 
 (defun lordar-mode-line-segments--propertize (text face)
   "Propertize TEXT with the FACE.
@@ -291,7 +291,8 @@ Use FORMAT-STRING to change the output format."
                   ;; about modified.
                   (t '(buffer-read-only buffer-status-read-only))))
                 (symbol (lordar-mode-line-segments--get-symbol
-                         (car symbol-and-face) 'buffer-status))
+                         (car symbol-and-face)
+                         'lordar-mode-line-buffer-status-symbols))
                 (symbol-formatted (if format-string
                                       (format format-string symbol)
                                     symbol))
@@ -379,8 +380,8 @@ Use FORMAT-STRING to change the output format."
          (directory-formatted (if format-string
                                   (format format-string directory)
                                 directory)))
-    (setq lordar-mode-line-segments--project-root-relative-directory
-          directory-formatted)))
+    (setq-local lordar-mode-line-segments--project-root-relative-directory
+                directory-formatted)))
 
 (defun lordar-mode-line-segments-project-root-relative-directory (&optional format-string)
   "Return the directory path relative to the root of the project.
@@ -438,10 +439,14 @@ Set vc branch text as car and vc state symbol as cdr."
 (defun lordar-mode-line-segments--vc-branch-get ()
   "Return the vc branch name for the current buffer."
   (when (and vc-mode buffer-file-name)
-    (when-let* ((backend (vc-backend buffer-file-name)))
+    (let* ((backend (vc-backend buffer-file-name))
+           (s (substring-no-properties vc-mode)))
       (cond
-       ((equal backend 'Git) (substring-no-properties vc-mode 5))
-       ((equal backend 'Hg) (substring-no-properties vc-mode 4))))))
+       ((eq backend 'Git)
+        (if (>= (length s) 6) (substring s 5) s)) ;; " Git:" = 5 chars
+       ((eq backend 'Hg)
+        (if (>= (length s) 5) (substring s 4) s)) ;; " Hg:"  = 4 chars
+       (t nil)))))
 
 (defun lordar-mode-line-segments-vc-branch (&optional format-string)
   "Return the vc branch formatted to display in the mode line.
@@ -537,7 +542,9 @@ This is used for conflicts."
                               ((eq state 'conflict) 'conflict)
                               ((eq state 'ignored) 'ignored)
                               (t 'default))))
-      (lordar-mode-line-segments--get-symbol symbol 'vc-state))))
+      (lordar-mode-line-segments--get-symbol
+       symbol
+       'lordar-mode-line-vc-state-symbols))))
 
 (defun lordar-mode-line-segments--vc-state-get ()
   "Return an indicator representing the status of the current buffer.
@@ -551,7 +558,7 @@ Uses symbols defined in `lordar-mode-line-buffer-status-symbols'."
   "Return the face symbol for the vc STATE."
   (when (and vc-mode buffer-file-name)
     (when-let* ((state (or state (vc-state buffer-file-name))))
-      (cond ((memq state '(up-to-date removed ignore)) 'vc-state)
+      (cond ((memq state '(up-to-date removed ignored)) 'vc-state)
             ((memq state '(edited needs-update needs-merge added))
              'vc-state-dirty)
             ((memq state '(conflict)) 'vc-state-error)
@@ -672,7 +679,7 @@ Use FORMAT-STRING to change the output."
     (dolist (d (flymake-diagnostics))
       (when (= (flymake--severity type)
                (flymake--severity (flymake-diagnostic-type d)))
-        (cl-incf count)))
+        (setq count (+ 1 count))))
     (number-to-string count)))
 
 (defun lordar-mode-line-segments--syntax-checking (type &optional format-string
@@ -777,7 +784,6 @@ Use FORMAT-STRING to change the output."
 (defun lordar-mode-line-segments-winum (&optional format-string)
   "Return the winum number string for the mode line.
 Use FORMAT-STRING to change the output."
-  (setq winum-auto-setup-mode-line nil)
   (when (and (featurep 'winum)
              (bound-and-true-p winum-mode))
     (when-let* ((nr (winum-get-number-string))

--- a/lisp/lordar-mode-line.el
+++ b/lisp/lordar-mode-line.el
@@ -1,11 +1,11 @@
 ;;; lordar-mode-line.el --- Minimal mode-line -*- lexical-binding: t -*-
 
-;; Copyright (C) 2024 Daniel Hubmann
+;; Copyright (C) 2024-2026 Daniel Hubmann
 
 ;; Author: Daniel Hubmann <hubisan@gmail.com>
 ;; Maintainer: Daniel Hubmann <hubisan@gmail.com>
 ;; URL: https://github.com/hubisan/lordar-mode-line
-;; Version: 0.1.0
+;; Version: 0.2.0
 ;; Package-Requires: ((emacs "29.4"))
 ;; Keywords: mode-line faces
 

--- a/tests/test-lordar-mode-line.el
+++ b/tests/test-lordar-mode-line.el
@@ -7,6 +7,8 @@
 (require 'buttercup)
 (require 'ert)
 
+(require 'cl-lib)
+
 (require 'lordar-mode-line)
 
 (require 'project)
@@ -63,15 +65,19 @@
               (buffer-read-only . "%%"))))
 
     (it "returns the symbol associated with the key when it exists"
-      (expect (lordar-mode-line-segments--get-symbol 'buffer-modified 'buffer-status)
+      (expect (lordar-mode-line-segments--get-symbol
+               'buffer-modified
+               'lordar-mode-line-buffer-status-symbols)
               :to-equal "*"))
 
     (it "raises an error when the symbols alist doesn't exist"
-      (expect (lordar-mode-line-segments--get-symbol 'buffer-modified 'non-existent-status)
+      (expect (lordar-mode-line-segments--get-symbol
+               'buffer-modified 'non-existent-status)
               :to-throw 'user-error))
 
     (it "raises an error when the key doesn't exist in the symbols alist"
-      (expect (lordar-mode-line-segments--get-symbol 'non-existent-key 'buffer-status)
+      (expect (lordar-mode-line-segments--get-symbol
+               'non-existent-key 'lordar-mode-line-buffer-status-symbols)
               :to-throw 'user-error))))
 
 ;;;; Segments
@@ -85,28 +91,36 @@
         (setq lordar-mode-line-height-adjust-factor 0.2))
 
       (it "adjusts the height of the mode-line using the default factor"
-        (let* ((factor 0.2)
-               (top (propertize " " 'display
-                                `((space-width 0.01) (raise ,factor))))
-               (bottom (propertize " " 'display
-                                   `((space-width 0.01) (raise ,(* -1 factor)))))
-               (expected (propertize (concat top bottom) 'face
-                                     'lordar-mode-line-height-adjust)))
-          (should (equal-including-properties
-                   expected
-                   (lordar-mode-line-segments-adjust-height)))))
+        (cl-letf (((symbol-function 'display-graphic-p)
+                   (lambda (&optional _frame) t)))
+          (let* ((factor 0.2)
+                 (top (propertize " " 'display
+                                  `((space-width 0.01) (raise ,factor))))
+                 (bottom (propertize " " 'display
+                                     `((space-width 0.01) (raise ,(* -1 factor)))))
+                 (expected (propertize (concat top bottom) 'face
+                                       'lordar-mode-line-height-adjust)))
+            (should (equal-including-properties
+                     expected
+                     (lordar-mode-line-segments-adjust-height))))))
 
       (it "adjusts the height of the mode-line using a provided factor"
-        (let* ((factor 0.3)
-               (top (propertize " " 'display
-                                `((space-width 0.01) (raise ,factor))))
-               (bottom (propertize " " 'display
-                                   `((space-width 0.01) (raise ,(* -1 factor)))))
-               (expected (propertize (concat top bottom) 'face
-                                     'lordar-mode-line-height-adjust)))
-          (should (equal-including-properties
-                   expected
-                   (lordar-mode-line-segments-adjust-height 0.3)))))))
+        (cl-letf (((symbol-function 'display-graphic-p)
+                   (lambda (&optional _frame) t)))
+          (let* ((factor 0.3)
+                 (top (propertize " " 'display
+                                  `((space-width 0.01) (raise ,factor))))
+                 (bottom (propertize " " 'display
+                                     `((space-width 0.01) (raise ,(* -1 factor)))))
+                 (expected (propertize (concat top bottom) 'face
+                                       'lordar-mode-line-height-adjust)))
+            (should (equal-including-properties
+                     expected
+                     (lordar-mode-line-segments-adjust-height 0.3))))))
+      (it "returns empty string in TTY"
+        (cl-letf (((symbol-function 'display-graphic-p)
+                   (lambda (&optional _frame) nil)))
+          (should (equal "" (lordar-mode-line-segments-adjust-height)))))))
 
   (describe "> Vertical Space"
     (describe "- lordar-mode-line-segments-vertical-space"


### PR DESCRIPTION

- Fix mode-line truncation in narrow window
- Introduce :left-important segment group and document it in defcustoms, This is needed for 'intelligent' truncation.
- Allow safe local variables without prompting for tests with Eask
- Disable winum auto mode-line setup more robustly
- Simplify and harden vc branch detection
- Update --get-symbol to accept variable symbols directly
- Apply small internal cleanups and micro-optimizations
- Fix Buttercup tests and resolve elint/package-lint warnings
- Update README and prepare release 0.2.0

Fixes #1 